### PR TITLE
tests/unittests: add tests for scanf_float.

### DIFF
--- a/tests/unittests/tests-scanf_float/Makefile
+++ b/tests/unittests/tests-scanf_float/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-scanf_float/Makefile.include
+++ b/tests/unittests/tests-scanf_float/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += scanf_float

--- a/tests/unittests/tests-scanf_float/tests-scanf_float.c
+++ b/tests/unittests/tests-scanf_float/tests-scanf_float.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     unittests
+ * @{
+ *
+ * @file
+ * @brief       Test scanf with floating-point numbers (scanf_float).
+ *
+ * @author      Juan Carrano <j.carrano@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "embUnit/embUnit.h"
+
+#include "tests-scanf_float.h"
+
+
+#define TEST_EASY(name, format, constant) static void test_ ## name (void) \
+{\
+    int items;\
+    float x = 0;\
+    items = sscanf(#constant, format, &x);\
+    TEST_ASSERT_EQUAL_INT(items, 1); \
+    TEST_ASSERT(x == constant##f);\
+}
+
+TEST_EASY(f, "%f", 2.71828)
+TEST_EASY(e, "%e", 2.71828)
+TEST_EASY(E, "%E", 2.71828)
+TEST_EASY(g, "%g", 2.71828)
+
+/* This does not seem to be supported in newlib-nano. */
+/*TEST_EASY(a, "%a", 2.71828)*/
+
+TEST_EASY(sign, "%f", -.785398)
+
+static void test_scientific(void)
+{
+    int items;
+    float x = 0;
+
+    items = sscanf("-3.21e2", "%f", &x);
+    TEST_ASSERT_EQUAL_INT(items, 1);
+    TEST_ASSERT(x == -321.0f);
+}
+/* This does not seem to be supported in newlib-nano. */
+/*
+static void test_hexa(void)
+{
+    int items;
+    float x = 0;
+
+    items = sscanf("0xA.A", "%f", &x);
+    TEST_ASSERT_EQUAL_INT(items, 1);
+    TEST_ASSERT(x == 0xA.Ap0f);
+}
+*/
+Test *tests_scanf_float_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_f),
+        new_TestFixture(test_e),
+        new_TestFixture(test_E),
+        new_TestFixture(test_g),
+    /*  new_TestFixture(test_a),    */
+        new_TestFixture(test_sign),
+        new_TestFixture(test_scientific),
+    /*  new_TestFixture(test_hexa), */
+    };
+
+    EMB_UNIT_TESTCALLER(scanf_float_tests,
+                        NULL, NULL,
+                        fixtures);
+
+    return (Test *)&scanf_float_tests;
+}
+
+void tests_scanf_float(void)
+{
+    TESTS_RUN(tests_scanf_float_tests());
+}

--- a/tests/unittests/tests-scanf_float/tests-scanf_float.h
+++ b/tests/unittests/tests-scanf_float/tests-scanf_float.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Test scanf with floating-point numbers (scanf_float).
+ *
+ * @author      Juan Carrano <j.carrano@fu-berlin.de>
+ */
+
+#ifndef TESTS_SCANF_FLOAT_H
+#define TESTS_SCANF_FLOAT_H
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Generates tests for scanf_float
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_scanf_float_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_SCANF_FLOAT_H */


### PR DESCRIPTION
### Contribution description

I added a unit test for this features. This turned out to be quite useful as it allowed me to see that not every specifier is supported.

Newlib-nano does not seem to support hexadecimal floats or the %a specifier. What is even weirder, it reports a successful conversion anyways.

Tests for these two cases have been commented out.

### Testing procedure

Just run the unit test.
